### PR TITLE
Added the ability to read token/password/username from non-tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ testdata/
 rwms_unknown_mods_*
 rwms_database.json
 
+github.token
+github.username

--- a/RWMS/configuration.py
+++ b/RWMS/configuration.py
@@ -10,9 +10,9 @@ if sys.platform == "win32":
     import winreg
 
 
-def configuration_file():
+def get_file_path(filename):
     """
-    returns the configuration file as a string, empty if not detected.
+    returns the path of the given filename relative to the location of the executable
     :return: str
     """
 
@@ -24,7 +24,16 @@ def configuration_file():
     elif __file__:
         mypath = os.path.dirname(sys.argv[0])
 
-    return os.path.join(mypath, "rwms_config.ini")
+    return os.path.join(mypath, filename)
+
+
+def configuration_file():
+    """
+    returns the configuration file as a string, empty if not detected.
+    :return: str
+    """
+
+    return get_file_path("rwms_config.ini")
 
 
 def load_value(section, entry, isBool=False):
@@ -53,6 +62,19 @@ def load_value(section, entry, isBool=False):
             value = cfg.getboolean(section, entry)
         else:
             value = cfg.get(section, entry, raw=True)
+            if value == '' and section == 'github':
+                if entry == 'github_password':
+                    # check for a token file if no password was defined
+                    tokenfile = get_file_path("github.token")
+                    if os.path.isfile(tokenfile):
+                        with open(tokenfile) as f:
+                            value = f.read().strip()
+                elif entry == 'github_username':
+                    # check for a username file if no username was defined
+                    username_file = get_file_path("github.username")
+                    if os.path.isfile(username_file):
+                        with open(username_file) as f:
+                            value = f.read().strip()
     except:
         print("Error parsing entry '{}', section '{}' from configuration file '{}'".format(entry, section, configfile))
         input("Press ENTER to end program.")

--- a/rwms_config.ini
+++ b/rwms_config.ini
@@ -49,10 +49,16 @@ localmodsdir =
 ; -- GitHub authentication
 ; fill in for automatically submitting missing mods
 ; if you leave this empty, the script won't be able to this and skips silently over it.
+; If you have a personal authentication token, you can use it in place of a password.
+; If you do not wish to store your username or password in this file, see below.
 [github]
 github_username =
 github_password =
 ;
-; I do know that there is a better solution (with authentication token), but I did not get
-; this to work with just access to issues and nothing more. If you can provide a solution
-; please open an issue on GitHub.
+; If you do not want to store your credentials in this file, you can put your token or
+; password in a file called 'github.token' and your username in a file called 'github.username'.
+; If you only want to store one of those pieces of information in a file, you can still
+; do so. The program will check the config first and only if you didn't define it in the
+; config will it check the files specified above.
+;
+; NOTE: If you use a personal access token, make sure it has the 'public_repo' permission.


### PR DESCRIPTION
Apparently personal access tokens can be used in place of passwords for GitHub. I added some functionality that allows the program to read from untracked files in the repo for those of us who execute from the same folder that we make changes in.